### PR TITLE
GLUE-5576 added back port

### DIFF
--- a/src/Spryker/Glue/OrdersRestApi/Processor/Order/OrderReader.php
+++ b/src/Spryker/Glue/OrdersRestApi/Processor/Order/OrderReader.php
@@ -7,9 +7,9 @@
 
 namespace Spryker\Glue\OrdersRestApi\Processor\Order;
 
+use Generated\Shared\Transfer\FilterTransfer;
 use Generated\Shared\Transfer\OrderListTransfer;
 use Generated\Shared\Transfer\OrderTransfer;
-use Generated\Shared\Transfer\PaginationTransfer;
 use Generated\Shared\Transfer\RestErrorMessageTransfer;
 use Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceBuilderInterface;
 use Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface;
@@ -112,7 +112,7 @@ class OrderReader implements OrderReaderInterface
             $offset = $restRequest->getPage()->getOffset();
             $limit = $restRequest->getPage()->getLimit();
 
-            $orderListTransfer->setPagination($this->createPaginationTransfer(++$offset, $limit));
+            $orderListTransfer->setFilter($this->createFilterTransfer($offset, $limit));
         }
 
         $orderListTransfer = $this->salesClient->getPaginatedOrder($orderListTransfer);
@@ -176,12 +176,12 @@ class OrderReader implements OrderReaderInterface
      * @param int $offset
      * @param int $limit
      *
-     * @return \Generated\Shared\Transfer\PaginationTransfer
+     * @return \Generated\Shared\Transfer\FilterTransfer
      */
-    protected function createPaginationTransfer(int $offset, int $limit): PaginationTransfer
+    protected function createFilterTransfer(int $offset, int $limit): FilterTransfer
     {
-        return (new PaginationTransfer())
-            ->setPage($offset)
-            ->setMaxPerPage($limit);
+        return (new FilterTransfer())
+            ->setOffset($offset)
+            ->setLimit($limit);
     }
 }

--- a/src/Spryker/Shared/OrdersRestApi/Transfer/orders_rest_api.transfer.xml
+++ b/src/Spryker/Shared/OrdersRestApi/Transfer/orders_rest_api.transfer.xml
@@ -127,4 +127,35 @@
         <property name="quantity" type="int"/>
     </transfer>
 
+    <transfer name="Filter">
+        <property name="limit" type="int"/>
+        <property name="offset" type="int"/>
+    </transfer>
+
+    <transfer name="Pagination">
+        <property name="nbResults" type="int"/>
+    </transfer>
+
+    <transfer name="Order">
+        <property name="idSalesOrder" type="int"/>
+        <property name="orderReference" type="string"/>
+        <property name="customerReference" type="string"/>
+        <property name="totals" type="Totals"/>
+        <property name="billingAddress" type="Address"/>
+        <property name="shippingAddress" type="Address"/>
+    </transfer>
+
+    <transfer name="Address">
+        <property name="iso2Code" type="string" />
+        <property name="country" type="Country" />
+    </transfer>
+
+    <transfer name="Totals">
+        <property name="taxTotal" type="TaxTotal" />
+    </transfer>
+
+    <transfer name="TaxTotal">
+        <property name="amount" type="int" />
+    </transfer>
+
 </transfers>


### PR DESCRIPTION
Branch: `backport/glue-5578-orders-rest-api-backport`.
Ticket: https://spryker.atlassian.net/browse/GLUE-5578.
Main PR: https://github.com/spryker/spryker/pull/6012.
Target version: **3.0.1**

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   OrdersRestApi               | patch                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module OrdersRestApi

##### Change log

### Improvements

- Adjusted `OrderReader` to use `OrderListTransfer::$filter` instead of `OrderListTransfer::$pagination` to paginate the result.
